### PR TITLE
Add setting sample with coc.nvim in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ connections:
 
 ### Workspace configuration Sample
 
-Below is a setting example with vim-lsp.
-**I'm sorry. Please wait a little longer for other editor settings.**
+* setting example with vim-lsp.
 
 ```vim
 if executable('sqls')
@@ -142,6 +141,24 @@ if executable('sqls')
     augroup END
 endif
 ```
+
+* setting example with coc.nvim.
+
+In `coc-settings.json` opened by `:CocConfig`
+
+```json
+{
+    "languageserver": {
+        "sql": {
+            "command": "sqls",
+            "args": ["-config", "$HOME/.config/sqls/config.yml"],
+            "filetypes": ["sql"]
+        }
+    }
+}
+```
+
+**I'm sorry. Please wait a little longer for other editor settings.**
 
 ### Configuration Params
 


### PR DESCRIPTION
Hi, thank you for a good job.
In my case, I am using [coc.nvim](https://github.com/neoclide/coc.nvim) instead of vim-lsp, and I made settings so that sqls can be run with coc.nvim.
This update describes the items set at that time.

Please check it.
Thanks!