### PR TITLE
Fix sample settings in the README (YAML error and coc.nvim)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Whichever method you choose, the settings you make will remain the same.
 ```yaml
 connections:
   - alias: dsn_mysql
-    'driver': 'mysql',
-    'dataSourceName': 'root:root@tcp(127.0.0.1:13306)/world',
+    driver: mysql
+    dataSourceName: root:root@tcp(127.0.0.1:13306)/world
   - alias: individual_mysql
     driver: mysql
     proto: tcp

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ In `coc-settings.json` opened by `:CocConfig`
         "sql": {
             "command": "sqls",
             "args": ["-config", "$HOME/.config/sqls/config.yml"],
-            "filetypes": ["sql"]
+            "filetypes": ["sql"],
+            "shell": true
         }
     }
 }


### PR DESCRIPTION
- Fixed an incorrect YAML description in Sample configuration, which was causing a parse error
- The `languageserver` entry for coc.nvim is for node modules by default.
   In order to expand the `$HOME` of the shell feature, you need to add a configuration for `shell: true`.