### PR TITLE
Use XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Whichever method you choose, the settings you make will remain the same.
 1. Configuration file specified by the `-config` flag
 1. `workspace/configuration` set to LSP client
 1. Configuration file located in the following location
-    - `$HOME`/.config/sqls/config.yml
+    - `$XDG_CONFIG_HOME`/sqls/config.yml ("`$HOME`/.config" is used instead of `$XDG_CONFIG_HOME` if it's not set)
 
 ### Configuration file sample
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,10 +76,15 @@ func IsFileExist(fPath string) bool {
 }
 
 func configFilePath(fileName string) string {
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		return filepath.Join(xdgConfigHome, "sqls", fileName)
+	}
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)
 	}
+
 	return filepath.Join(homeDir, ".config", "sqls", fileName)
 }
 


### PR DESCRIPTION
Use `XDG_CONFIG_HOME` variable if it is set.

If it's not, then as stated in XDG Base Directory specification, fall back to `$HOME/.config`