### PR TITLE
Handle "shutdown" requests and "exit" notifications

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -92,6 +92,8 @@ func (s *Server) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.
 		return
 	case "shutdown":
 		return s.handleShutdown(ctx, conn, req)
+	case "exit":
+		return s.handleExit(ctx, conn, req)
 	case "textDocument/didOpen":
 		return s.handleTextDocumentDidOpen(ctx, conn, req)
 	case "textDocument/didChange":
@@ -152,14 +154,18 @@ func (s *Server) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn, req 
 }
 
 func (s *Server) handleShutdown(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
-	if req.Params == nil {
-		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
-	}
-
 	if s.dbConn != nil {
 		s.dbConn.Close()
 	}
 	return nil, nil
+}
+
+func (s *Server) handleExit(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+	if s.dbConn != nil {
+		s.dbConn.Close()
+	}
+	err = s.Stop()
+	return nil, err
 }
 
 func (s *Server) handleTextDocumentDidOpen(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {


### PR DESCRIPTION
The "shutdown" request prevously required paramters, but my LSP client (vim-lsc)
doesn't send them, resulting in the error:

	StdErr from 'sqls -trace': jsonrpc2: --> request #2: shutdown: null
	StdErr from 'sqls -trace': 2020/12/08 15:41:51 error serving, jsonrpc2: code -32602 message:
	StdErr from 'sqls -trace': jsonrpc2: <-- error #2: shutdown: {"code":-32602,"message":"","data":null}

Checking the specification[1], the params are defined as "void", so I think
checking this is an error?

---

My LSP client also sends an exit notification[2], which wasn't handled:

	StdErr from 'sqls -trace': jsonrpc2: --> notif: exit: null
	StdErr from 'sqls -trace': 2020/12/08 15:47:52 error serving, jsonrpc2: code -32601 message: method not supported: exit
	StdErr from 'sqls -trace': jsonrpc2 handler: notification "exit" handling error: jsonrpc2: code -32601 message: method not supported: exit

So handle this as well.

After these changes sqls shuts down cleanly, without errors and delaying my :q
in vim for ~4 seconds.

[1]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#shutdown
[2]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#exit