### PR TITLE
Add "lowercaseKeywords" configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Whichever method you choose, the settings you make will remain the same.
 ### Configuration file sample
 
 ```yaml
+# Set to true to use lowercase keywords instead of uppercase.
+lowercaseKeywords: false
 connections:
   - alias: dsn_mysql
     driver: mysql

--- a/internal/completer/candidates.go
+++ b/internal/completer/candidates.go
@@ -9,13 +9,16 @@ import (
 	"github.com/lighttiger2505/sqls/parser/parseutil"
 )
 
-func (c *Completer) keywordCandidates() []lsp.CompletionItem {
+func (c *Completer) keywordCandidates(lower bool) []lsp.CompletionItem {
 	candidates := []lsp.CompletionItem{}
 	for _, k := range keywords {
 		candidate := lsp.CompletionItem{
 			Label:  k,
 			Kind:   lsp.KeywordCompletion,
 			Detail: "keyword",
+		}
+		if lower {
+			candidate.Label = strings.ToLower(candidate.Label)
 		}
 		candidates = append(candidates, candidate)
 	}

--- a/internal/completer/completer.go
+++ b/internal/completer/completer.go
@@ -103,7 +103,7 @@ func completionTypeIs(completionTypes []completionType, expect completionType) b
 	return false
 }
 
-func (c *Completer) Complete(text string, params lsp.CompletionParams) ([]lsp.CompletionItem, error) {
+func (c *Completer) Complete(text string, params lsp.CompletionParams, lowercaseKeywords bool) ([]lsp.CompletionItem, error) {
 	parsed, err := parser.Parse(text)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func (c *Completer) Complete(text string, params lsp.CompletionParams) ([]lsp.Co
 		items = append(items, c.SubQueryColumnCandidates(definedSubQuerys)...)
 	}
 	if completionTypeIs(ctx.types, CompletionTypeKeyword) {
-		items = append(items, c.keywordCandidates()...)
+		items = append(items, c.keywordCandidates(lowercaseKeywords)...)
 	}
 
 	items = filterCandidates(items, lastWord)

--- a/internal/completer/completer_test.go
+++ b/internal/completer/completer_test.go
@@ -1,7 +1,10 @@
 package completer
 
 import (
+	"reflect"
 	"testing"
+
+	"github.com/lighttiger2505/sqls/internal/lsp"
 )
 
 func TestGetBeforeCursorText(t *testing.T) {
@@ -100,6 +103,60 @@ func Test_completionTypeIs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := completionTypeIs(tt.completionTypes, tt.expect); got != tt.want {
 				t.Errorf("completionTypeIs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComplete(t *testing.T) {
+	tests := []struct {
+		name      string
+		text      string
+		lowerCase bool
+		expected  []lsp.CompletionItem
+	}{
+		{
+			name: "keyword",
+			text: "sel",
+			expected: []lsp.CompletionItem{
+				{
+					Label:  "SELECT",
+					Kind:   lsp.KeywordCompletion,
+					Detail: "keyword",
+				},
+			},
+		},
+		{
+			name:      "keyword-lowercase",
+			text:      "sel",
+			lowerCase: true,
+			expected: []lsp.CompletionItem{
+				{
+					Label:  "select",
+					Kind:   lsp.KeywordCompletion,
+					Detail: "keyword",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			c := NewCompleter(nil)
+			got, err := c.Complete("sel", lsp.CompletionParams{
+				TextDocumentPositionParams: lsp.TextDocumentPositionParams{
+					Position: lsp.Position{
+						Line:      0,
+						Character: len(tt.text),
+					},
+				},
+			}, tt.lowerCase)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("\nwant: %v\ngot:  %v", tt.expected, got)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,8 @@ var (
 )
 
 type Config struct {
-	Connections []*database.DBConfig `json:"connections" yaml:"connections"`
+	LowercaseKeywords bool                 `json:"lowercaseKeywords" yaml:"lowercaseKeywords"`
+	Connections       []*database.DBConfig `json:"connections" yaml:"connections"`
 }
 
 func newConfig() *Config {

--- a/internal/handler/completion.go
+++ b/internal/handler/completion.go
@@ -29,7 +29,7 @@ func (s *Server) handleTextDocumentCompletion(ctx context.Context, conn *jsonrpc
 		return nil, fmt.Errorf("database cache not found")
 	}
 	c := completer.NewCompleter(s.worker.Cache())
-	completionItems, err := c.Complete(f.Text, params)
+	completionItems, err := c.Complete(f.Text, params, s.getConfig().LowercaseKeywords)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I don't really like to put all SQL keywords as uppercase, so I'd write
"select x from foo" rather than "SELECT x FROM foo".

But sqls will always complete it to uppercase. This change adds a
setting to config.yml to change it to lowercase.

Note: I didn't add a test yet, let me know if this looks okay to you and
I'll work on adding a test too.