### PR TITLE
Add "sqls/config.yml" JSON schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "additionalProperties": false,
+  "definitions": {
+    "connection-definition": {
+      "description": "Database connections",
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "alias": {
+            "description": "Connection alias name. Optional",
+            "type": "string"
+          },
+          "driver": {
+            "description": "mysql, postgresql, sqlite3. Required",
+            "type": "string",
+            "enum": [
+              "mysql",
+              "postgresql",
+              "sqlite3"
+            ]
+          },
+          "dataSourceName": {
+            "description": "Data source name",
+            "type": "string"
+          },
+          "proto": {
+            "description": "tcp, udp, unix",
+            "type": "string",
+            "enum": [
+              "tcp",
+              "udp",
+              "unix"
+            ]
+          },
+          "user": {
+            "description": "User name",
+            "type": "string"
+          },
+          "passwd": {
+            "description": "Password",
+            "type": "string"
+          },
+          "host": {
+            "description": "Host",
+            "type": "string"
+          },
+          "port": {
+            "description": "Port",
+            "type": "number"
+          },
+          "path": {
+            "description": "unix socket path",
+            "type": "string"
+          },
+          "dbName": {
+            "description": "Database name",
+            "type": "string"
+          },
+          "params": {
+            "description": "Option params. Optional",
+            "type": "object",
+            "properties": {}
+          },
+          "sshConfig": {
+            "description": "ssh config. Optional",
+            "type": "object",
+            "properties": {
+              "host": {
+                "description": "ssh host. Required",
+                "type": "string"
+              },
+              "port": {
+                "description": "ssh port. Required",
+                "type": "number"
+              },
+              "user": {
+                "description": "ssh user. Optional",
+                "type": "string"
+              },
+              "privateKey": {
+                "description": "private key path. Required",
+                "type": "string"
+              },
+              "passPhrase": {
+                "description": "passPhrase. Optional",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "lowercaseKeywords": {
+      "description": "Set to true to use lowercase keywords instead of uppercase.",
+      "type": "boolean"
+    },
+    "connections": {
+      "$ref": "#/definitions/connection-definition"
+    }
+  },
+  "title": "sqls",
+  "type": "object"
+}


### PR DESCRIPTION
Description
-------------------------------------------------------

"`yaml-language-server`" allows you to use JSON schema for completion, linting and hover. <https://github.com/redhat-developer/yaml-language-server#using-yamlschemas-settings>

For example, `efm-langserver` and `vim-lsp-settings` also have JSON schema.

- <https://github.com/mattn/efm-langserver/blob/master/schema.json>
- <https://github.com/mattn/vim-lsp-settings/blob/master/schema.json>

I have created a JSON schema for `sqls/config.yml`.

Configuration example
-------------------------------------------------------

> I'm currently setting up the schema for my PR branch.
> After merging, please set the sqls URL

### vim-lsp

```vim
if executable('yaml-language-server')
 augroup LspYaml
   au!
   autocmd User lsp_setup call lsp#register_server({
       \ 'name': 'yaml-language-server',
       \ 'cmd': {server_info->['yaml-language-server', '--stdio']},
       \ 'allowlist': ['yaml'],
       \ 'workspace_config': {
       \   'yaml': {
       \     'schemas': {
       \       'https://raw.githubusercontent.com/yaegassy/sqls/add-json-schema/schema.json': '/sqls/config.yml',
       \     },
       \   },
       \ }})
 augroup END
endif
```

### coc.nvim (+coc-yaml) | settings.json

```jsonc
{
  // ...snip
  "yaml.schemas": {
    "https://raw.githubusercontent.com/yaegassy/sqls/add-json-schema/schema.json": "/sqls/config.yml"
  },
  // ...snip
}
```

DEMO (vim-lsp)
-------------------------------------------------------

![sqls-json-schema](https://user-images.githubusercontent.com/188642/110577966-1a8e7f80-81a7-11eb-9be3-43d62080ba79.gif)

Notes
-------------------------------------------------------

If you don't need it at this time, you can close this PR. 😇
