### PR TITLE
Do not suggest all tables when the the schema is not found

### DIFF
--- a/internal/completer/candidates.go
+++ b/internal/completer/candidates.go
@@ -146,9 +146,6 @@ func (c *Completer) TableCandidates(parent *completionParent, targetTables []*pa
 		tables, ok := c.DBCache.SortedTablesByDBName(parent.Name)
 		if ok {
 			candidates = append(candidates, generateTableCandidates(tables, c.DBCache)...)
-		} else {
-			tables := c.DBCache.SortedTables()
-			candidates = append(candidates, generateTableCandidates(tables, c.DBCache)...)
 		}
 	case ParentTypeTable:
 		// pass

--- a/internal/completer/candidates.go
+++ b/internal/completer/candidates.go
@@ -160,7 +160,7 @@ func generateTableCandidates(tables []string, dbCache *database.DBCache) []lsp.C
 	for _, tableName := range tables {
 		candidate := lsp.CompletionItem{
 			Label:  tableName,
-			Kind:   lsp.FieldCompletion,
+			Kind:   lsp.ClassCompletion,
 			Detail: "table",
 		}
 		cols, ok := dbCache.ColumnDescs(tableName)
@@ -186,7 +186,7 @@ func generateTableCandidatesByInfos(tables []*parseutil.TableInfo, dbCache *data
 		}
 		candidate := lsp.CompletionItem{
 			Label:  name,
-			Kind:   lsp.FieldCompletion,
+			Kind:   lsp.ClassCompletion,
 			Detail: detail,
 		}
 		cols, ok := dbCache.ColumnDescs(table.Name)
@@ -275,7 +275,7 @@ func (c *Completer) SchemaCandidates() []lsp.CompletionItem {
 	for _, db := range dbs {
 		candidate := lsp.CompletionItem{
 			Label:  db,
-			Kind:   lsp.FieldCompletion,
+			Kind:   lsp.ModuleCompletion,
 			Detail: "schema",
 		}
 		candidates = append(candidates, candidate)

--- a/internal/completer/completer.go
+++ b/internal/completer/completer.go
@@ -187,10 +187,13 @@ func getSortTextPrefix(kind lsp.CompletionItemKind) string {
 	switch kind {
 	case lsp.FieldCompletion:
 		return "0"
+	case lsp.ClassCompletion:
+		return "1"
+	case lsp.ModuleCompletion:
+		return "2"
 	case lsp.FunctionCompletion:
 		return "10"
 	case
-		lsp.ClassCompletion,
 		lsp.ColorCompletion,
 		lsp.ConstantCompletion,
 		lsp.ConstructorCompletion,
@@ -202,7 +205,6 @@ func getSortTextPrefix(kind lsp.CompletionItemKind) string {
 		lsp.InterfaceCompletion,
 		lsp.KeywordCompletion,
 		lsp.MethodCompletion,
-		lsp.ModuleCompletion,
 		lsp.OperatorCompletion,
 		lsp.PropertyCompletion,
 		lsp.ReferenceCompletion,


### PR DESCRIPTION
I'm not sure what this code was for in the first place

assuming you're asking a completion on:
```sql
SELECT *
FROM customer.
```

sqls will suggest `customer` so you'll get:
```sql
SELECT *
FROM customer.customer
```
which is obviously wrong
