### PR TITLE
internal/formatter: fix incorrect formatting with INSERT INTO

### DIFF
--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -249,6 +249,7 @@ func formatMultiKeyword(node *ast.MultiKeyword, env *formatEnvironment) ast.Node
 		}
 	}
 
+	insertKeyword := "INSERT INTO"
 	joinKeywords := []string{
 		"INNER JOIN",
 		"CROSS JOIN",
@@ -264,7 +265,7 @@ func formatMultiKeyword(node *ast.MultiKeyword, env *formatEnvironment) ast.Node
 	}
 
 	whitespaceAfterMatcher := astutil.NodeMatcher{
-		ExpectKeyword: joinKeywords,
+		ExpectKeyword: append(joinKeywords, insertKeyword),
 	}
 	if whitespaceAfterMatcher.IsMatch(node) {
 		results = append(results, whitespaceNode)

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -4,8 +4,39 @@ import (
 	"testing"
 
 	"github.com/lighttiger2505/sqls/ast"
+	"github.com/lighttiger2505/sqls/internal/config"
+	"github.com/lighttiger2505/sqls/internal/lsp"
 	"github.com/lighttiger2505/sqls/parser"
 )
+
+func TestEval(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    string
+		params   lsp.DocumentFormattingParams
+		config   *config.Config
+		expected string
+	}{
+		{
+			name:     "InsertIntoFormat",
+			input:    "INSERT INTO users (NAME, email) VALUES ('john doe', 'example@host.com')",
+			expected: "INSERT INTO users(\n\tNAME,\n\temail\n)\nVALUES(\n'john doe',\n'example@host.com'\n)",
+			params:   lsp.DocumentFormattingParams{},
+			config: &config.Config{
+				LowercaseKeywords: false,
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, _ := Format(tt.input, tt.params, tt.config)
+			if actual[0].NewText != tt.expected {
+				t.Errorf("expected: %s, got %s", tt.expected, actual[0].NewText)
+			}
+		})
+	}
+}
 
 func TestRenderIdentifier(t *testing.T) {
 	testcases := []struct {


### PR DESCRIPTION
I saw an old PR of yours that refactors `formatter` so I don't know if this fix will get in the way of your changes but it fixes the formatting for when the query has an `INSERT INTO` statement.

Closes #74