### PR TITLE
Update installation go cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If the tables are connected with a foreign key sqls can complete ```JOIN``` stat
 ## Installation
 
 ```shell
-go get github.com/lighttiger2505/sqls
+go install github.com/lighttiger2505/sqls@latest
 ```
 
 ## Editor Plugins


### PR DESCRIPTION
`go get` is deprecated and returns an error:
```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```
Updating to use `go install` instead.