### PR TITLE
Fix query execution range handling and row iteration errors

### DIFF
--- a/internal/database/scan_row.go
+++ b/internal/database/scan_row.go
@@ -49,6 +49,9 @@ func ScanRows(rows *sql.Rows, columnLength int) ([][]string, error) {
 		}
 		stringRows = append(stringRows, stringRow)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return stringRows, nil
 }
 

--- a/internal/database/scan_row_test.go
+++ b/internal/database/scan_row_test.go
@@ -1,6 +1,35 @@
 package database
 
-import "testing"
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+)
+
+func TestScanRows_returnsRowsErr(t *testing.T) {
+	db := openScanRowsTestDB(t)
+	defer db.Close()
+
+	rows, err := db.QueryContext(context.Background(), "SELECT 1")
+	if err != nil {
+		t.Fatalf("QueryContext() error = %v", err)
+	}
+	defer rows.Close()
+
+	columns, err := Columns(rows)
+	if err != nil {
+		t.Fatalf("Columns() error = %v", err)
+	}
+
+	_, err = ScanRows(rows, len(columns))
+	if !errors.Is(err, errScanRowsTest) {
+		t.Fatalf("ScanRows() error = %v, want %v", err, errScanRowsTest)
+	}
+}
 
 func Test_sqlValToString_nilTypedPointer(t *testing.T) {
 	// Regression test: a typed nil pointer (e.g. (*string)(nil)) stored in
@@ -39,5 +68,74 @@ func Test_sqlValToString_validPointer(t *testing.T) {
 	}
 	if got != "hello" {
 		t.Errorf("expected %q, got %q", "hello", got)
+	}
+}
+
+var (
+	registerScanRowsTestDriverOnce sync.Once
+	errScanRowsTest                = errors.New("scan rows test error")
+)
+
+func openScanRowsTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	registerScanRowsTestDriverOnce.Do(func() {
+		sql.Register("scan_rows_test", scanRowsTestDriver{})
+	})
+
+	db, err := sql.Open("scan_rows_test", "")
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	return db
+}
+
+type scanRowsTestDriver struct{}
+
+func (scanRowsTestDriver) Open(string) (driver.Conn, error) {
+	return scanRowsTestConn{}, nil
+}
+
+type scanRowsTestConn struct{}
+
+func (scanRowsTestConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (scanRowsTestConn) Close() error {
+	return nil
+}
+
+func (scanRowsTestConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (scanRowsTestConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return &scanRowsTestRows{}, nil
+}
+
+type scanRowsTestRows struct {
+	calls int
+}
+
+func (r *scanRowsTestRows) Columns() []string {
+	return []string{"value"}
+}
+
+func (r *scanRowsTestRows) Close() error {
+	return nil
+}
+
+func (r *scanRowsTestRows) Next(dest []driver.Value) error {
+	switch r.calls {
+	case 0:
+		dest[0] = "ok"
+		r.calls++
+		return nil
+	case 1:
+		r.calls++
+		return errScanRowsTest
+	default:
+		return io.EOF
 	}
 }

--- a/internal/handler/execute_command.go
+++ b/internal/handler/execute_command.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -10,6 +9,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
@@ -178,30 +178,101 @@ func (s *Server) executeQuery(ctx context.Context, params lsp.ExecuteCommandPara
 }
 
 func extractRangeText(text string, startLine, startChar, endLine, endChar int) string {
-	writer := bytes.NewBufferString("")
-	scanner := bufio.NewScanner(strings.NewReader(text))
-
-	i := 0
-	for scanner.Scan() {
-		t := scanner.Text()
-		if i >= startLine && i <= endLine {
-			st, en := 0, len(t)
-
-			if i == startLine {
-				st = startChar
-			}
-			if i == endLine {
-				en = endChar
-			}
-
-			writer.Write([]byte(t[st:en]))
-			if i != endLine {
-				writer.Write([]byte("\n"))
-			}
-		}
-		i++
+	lines := strings.Split(text, "\n")
+	if startLine < 0 {
+		startLine = 0
 	}
-	return writer.String()
+	if endLine >= len(lines) {
+		endLine = len(lines) - 1
+	}
+	if startLine >= len(lines) || startLine > endLine {
+		return ""
+	}
+
+	var builder strings.Builder
+	for i := startLine; i <= endLine; i++ {
+		line := strings.TrimSuffix(lines[i], "\r")
+		st, en := 0, utf16Len(line)
+		if i == startLine {
+			st = startChar
+		}
+		if i == endLine {
+			en = endChar
+		}
+		builder.WriteString(sliceUTF16(line, st, en))
+		if i != endLine {
+			builder.WriteByte('\n')
+		}
+	}
+	return builder.String()
+}
+
+func utf16Len(s string) int {
+	length := 0
+	for _, r := range s {
+		length++
+		if r > utf8.MaxRune || r < 0 {
+			continue
+		}
+		if r > 0xFFFF {
+			length++
+		}
+	}
+	return length
+}
+
+func sliceUTF16(s string, start, end int) string {
+	if start < 0 {
+		start = 0
+	}
+	if end < start {
+		end = start
+	}
+
+	utf16Pos := 0
+	startByte, endByte := len(s), len(s)
+	startFound, endFound := false, false
+
+	for bytePos, r := range s {
+		runeWidth := 1
+		if r > 0xFFFF {
+			runeWidth = 2
+		}
+
+		if !startFound && start <= utf16Pos {
+			startByte = bytePos
+			startFound = true
+		}
+		if !endFound && end <= utf16Pos {
+			endByte = bytePos
+			endFound = true
+			break
+		}
+
+		nextUTF16Pos := utf16Pos + runeWidth
+		if !startFound && start < nextUTF16Pos {
+			startByte = bytePos
+			startFound = true
+		}
+		if !endFound && end < nextUTF16Pos {
+			endByte = bytePos + utf8.RuneLen(r)
+			endFound = true
+			break
+		}
+
+		utf16Pos = nextUTF16Pos
+	}
+
+	if !startFound && start <= utf16Pos {
+		startByte = len(s)
+	}
+	if !endFound {
+		endByte = len(s)
+	}
+	if startByte > endByte {
+		startByte = endByte
+	}
+	return s[startByte:endByte]
 }
 
 func (s *Server) query(ctx context.Context, query string, vertical bool) (string, error) {
@@ -213,6 +284,7 @@ func (s *Server) query(ctx context.Context, query string, vertical bool) (string
 	if err != nil {
 		return "", err
 	}
+	defer func() { _ = rows.Close() }()
 	columns, err := database.Columns(rows)
 	if err != nil {
 		return "", err

--- a/internal/handler/execute_command_test.go
+++ b/internal/handler/execute_command_test.go
@@ -141,6 +141,28 @@ func Test_extractRangeText(t *testing.T) {
 			},
 			want: "lect",
 		},
+		{
+			name: "extract unicode using utf16 offsets",
+			args: args{
+				text:      "SELECT 'あ😀い';",
+				startLine: 0,
+				startChar: 8,
+				endLine:   0,
+				endChar:   12,
+			},
+			want: "あ😀い",
+		},
+		{
+			name: "extract long single line without scanner limit",
+			args: args{
+				text:      strings.Repeat("a", 70000) + "SELECT",
+				startLine: 0,
+				startChar: 70000,
+				endLine:   0,
+				endChar:   70006,
+			},
+			want: "SELECT",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes query execution edge cases in two places. It now propagates row iteration errors from `ScanRows`, and it makes selected-range execution handle UTF-16 character offsets correctly so multibyte text is not sliced incorrectly. It also removes the long single-line truncation risk from range extraction and ensures query result rows are closed after reading them.