### PR TITLE
Fix panics in parseutil on incomplete queries

### DIFF
--- a/parser/parseutil/extract.go
+++ b/parser/parseutil/extract.go
@@ -225,7 +225,11 @@ func parseInsertValues(reader *astutil.NodeReader) []ast.Node {
 	if !ok {
 		return []ast.Node{}
 	}
-	identList, ok := parenthesis.Inner().GetTokens()[0].(*ast.IdentifierList)
+	list := parenthesis.Inner().GetTokens()
+	if len(list) == 0 {
+		return []ast.Node{}
+	}
+	identList, ok := list[0].(*ast.IdentifierList)
 	if !ok {
 		return []ast.Node{}
 	}

--- a/parser/parseutil/extract_test.go
+++ b/parser/parseutil/extract_test.go
@@ -328,6 +328,24 @@ func TestExtractInsertValues(t *testing.T) {
 				"123, 'aaa', '2020'",
 			},
 		},
+		{
+			name:  "empty values",
+			input: "insert into city (ID) VALUES ()",
+			pos: token.Pos{
+				Line: 0,
+				Col:  30,
+			},
+			want: []string{},
+		},
+		{
+			name:  "open parenthesis",
+			input: "insert into city (ID) VALUES (",
+			pos: token.Pos{
+				Line: 0,
+				Col:  30,
+			},
+			want: []string{},
+		},
 	}
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/parser/parseutil/parseutil.go
+++ b/parser/parseutil/parseutil.go
@@ -293,8 +293,10 @@ func extractSubQueryColumns(selectStmt ast.TokenList) ([]*SubQueryColumn, []*Tab
 
 	// extract select identifiers
 	reader := astutil.NewNodeReader(selectStmt)
-	if !reader.NextNode(true) || !reader.NextNode(true) {
-		return []*SubQueryColumn{}, tables, nil
+	for i := 0; i < 2; i++ {
+		if !reader.NextNode(true) {
+			return []*SubQueryColumn{}, tables, nil
+		}
 	}
 	identsObj := reader.CurNode
 	cols, err := parseSubQueryColumns(identsObj, tables)

--- a/parser/parseutil/parseutil.go
+++ b/parser/parseutil/parseutil.go
@@ -292,7 +292,11 @@ func extractSubQueryColumns(selectStmt ast.TokenList) ([]*SubQueryColumn, []*Tab
 	}
 
 	// extract select identifiers
-	identsObj := selectStmt.GetTokens()[2]
+	reader := astutil.NewNodeReader(selectStmt)
+	if !reader.NextNode(true) || !reader.NextNode(true) {
+		return []*SubQueryColumn{}, tables, nil
+	}
+	identsObj := reader.CurNode
 	cols, err := parseSubQueryColumns(identsObj, tables)
 	if err != nil {
 		return nil, nil, err
@@ -444,10 +448,12 @@ func aliasedToTableInfo(aliased *ast.Aliased) (*TableInfo, error) {
 	case *ast.Parenthesis:
 		tables, err := extractAllTableIdentifiers(v.Inner(), true)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
-		ti.DatabaseSchema = tables[0].DatabaseSchema
-		ti.Name = tables[0].Name
+		if len(tables) > 0 {
+			ti.DatabaseSchema = tables[0].DatabaseSchema
+			ti.Name = tables[0].Name
+		}
 	default:
 		return nil, fmt.Errorf(
 			"failed parse real name of alias, unknown node type %T, value %q",

--- a/parser/parseutil/parseutil_test.go
+++ b/parser/parseutil/parseutil_test.go
@@ -583,6 +583,30 @@ func TestExtractSubQueryViews(t *testing.T) {
 	}
 }
 
+func TestExtractSubQueryViewsIncomplete(t *testing.T) {
+	testcases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "empty select",
+			input: "select * from (select) as t",
+		},
+		{
+			name:  "nested sub query without from",
+			input: "select * from (select * from (select 1) as x) as y",
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			query := initExtractTable(t, tt.input)
+			if _, err := ExtractSubQueryViews(query, token.Pos{Line: 0, Col: 1}); err != nil {
+				t.Logf("error: %+v", err)
+			}
+		})
+	}
+}
+
 func TestExtractTable(t *testing.T) {
 	testcases := []struct {
 		name  string


### PR DESCRIPTION
Fixes three panics reachable from completion while typing incomplete SQL:

- `parseInsertValues` indexed the first token of an empty parenthesis, panicking on `insert into t (a) values ()` or `values (`.
- `extractSubQueryColumns` hardcoded `GetTokens()[2]` as the select expression, panicking on `select * from (select) as t` and misparsing when extra whitespace follows `SELECT`.
- `aliasedToTableInfo` indexed `tables[0]` without a length check and used `panic(err)` instead of returning the error, crashing on nested subqueries without a FROM clause such as `select * from (select * from (select 1) as x) as y`.

Regression tests added for each case.