### PR TITLE
Preserve asterisks in multiline comment content

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -115,10 +115,10 @@ func TestParseComments(t *testing.T) {
 			name:  "multi line range comment with identiger",
 			input: "/*\n * foo\n */\nbar",
 			checkFn: func(t *testing.T, stmts []*ast.Statement, input string) {
-				testStatement(t, stmts[0], 3, "/*\n   foo\n */\nbar")
+				testStatement(t, stmts[0], 3, "/*\n * foo\n */\nbar")
 
 				list := stmts[0].GetTokens()
-				testItem(t, list[0], "/*\n   foo\n */")
+				testItem(t, list[0], "/*\n * foo\n */")
 				testItem(t, list[1], "\n")
 				testIdentifier(t, list[2], "bar")
 			},

--- a/token/lexer.go
+++ b/token/lexer.go
@@ -505,9 +505,8 @@ func (t *Tokenizer) tokenizeMultilineComment() (string, error) {
 		if mayBeClosingComment {
 			if n == '/' {
 				break
-			} else {
-				str = append(str, n)
 			}
+			str = append(str, '*')
 		}
 		mayBeClosingComment = n == '*'
 		if !mayBeClosingComment {

--- a/token/lexer_test.go
+++ b/token/lexer_test.go
@@ -470,6 +470,18 @@ comment */`,
 			},
 		},
 		{
+			name: "/* comment with asterisk",
+			in:   `/* 1*2 */`,
+			out: []*Token{
+				{
+					Kind:  MultilineComment,
+					Value: " 1*2 ",
+					From:  Pos{Line: 0, Col: 0},
+					To:    Pos{Line: 0, Col: 9},
+				},
+			},
+		},
+		{
 			name: "operators",
 			in:   "1/1*1+1%1=1.1-.",
 			out: []*Token{


### PR DESCRIPTION
The multiline comment tokenizer dropped any `*` not followed by `/` and appended the following character twice, so `/* 1*2 */` was tokenized as `" 122 "`. Fix the closing-detection logic to emit the deferred asterisk correctly.

An existing parser test had encoded the corrupted output as its expected value; it is updated to expect the comment to round-trip unchanged.