### PR TITLE
Fix error handling and bounds checks in handler

### DIFF
--- a/internal/handler/execute_command.go
+++ b/internal/handler/execute_command.go
@@ -443,11 +443,14 @@ func (s *Server) switchConnections(ctx context.Context, params lsp.ExecuteComman
 		}
 	}
 	if index <= 0 {
-		index, _ = strconv.Atoi(indexStr)
+		index, err = strconv.Atoi(indexStr)
+		if err != nil {
+			return nil, fmt.Errorf("specify the connection index as a number, %w", err)
+		}
 	}
 
 	if index <= 0 {
-		return nil, fmt.Errorf("specify the connection index as a number, %w", err)
+		return nil, fmt.Errorf("specify the connection index as a number")
 	}
 	index = index - 1
 
@@ -501,7 +504,7 @@ func getStatements(text string) ([]*ast.Statement, error) {
 	for _, node := range parsed.GetTokens() {
 		stmt, ok := node.(*ast.Statement)
 		if !ok {
-			return nil, fmt.Errorf("invalid type want Statement parsed %T", stmt)
+			return nil, fmt.Errorf("invalid type want Statement parsed %T", node)
 		}
 		stmts = append(stmts, stmt)
 	}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -173,7 +173,7 @@ func (s *Server) handleInitialize(ctx context.Context, conn *jsonrpc2.Conn, req 
 	// NOTE: If no connection is found at this point, it is possible that the connection settings are sent to workspace config, so don't make an error
 	messenger := lsp.NewMessenger(conn)
 	if err := s.reconnectionDB(ctx); err != nil {
-		if !errors.Is(ErrNoConnection, err) {
+		if errors.Is(err, ErrNoConnection) {
 			if err := messenger.ShowInfo(ctx, err.Error()); err != nil {
 				log.Println("send info", err.Error())
 				return nil, err
@@ -232,6 +232,9 @@ func (s *Server) handleTextDocumentDidChange(ctx context.Context, conn *jsonrpc2
 		return nil, err
 	}
 
+	if len(params.ContentChanges) == 0 {
+		return nil, nil
+	}
 	if err := s.updateFile(params.TextDocument.URI, params.ContentChanges[0].Text); err != nil {
 		return nil, err
 	}
@@ -318,7 +321,7 @@ func (s *Server) handleWorkspaceDidChangeConfiguration(ctx context.Context, conn
 	// Initialize database database connection
 	messenger := lsp.NewMessenger(conn)
 	if err := s.reconnectionDB(ctx); err != nil {
-		if !errors.Is(ErrNoConnection, err) {
+		if errors.Is(err, ErrNoConnection) {
 			if err := messenger.ShowInfo(ctx, err.Error()); err != nil {
 				log.Println("send info", err.Error())
 				return nil, err
@@ -380,6 +383,9 @@ func (s *Server) newDBConnection(ctx context.Context) (*database.DBConnection, e
 }
 
 func (s *Server) newDBRepository(ctx context.Context) (database.DBRepository, error) {
+	if s.curDBCfg == nil || s.dbConn == nil {
+		return nil, ErrNoConnection
+	}
 	repo, err := database.CreateRepository(s.curDBCfg.Driver, s.dbConn.Conn)
 	if err != nil {
 		return nil, err
@@ -402,7 +408,7 @@ func (s *Server) topConnection() *database.DBConfig {
 
 func (s *Server) getConnection(index int) *database.DBConfig {
 	cfg := s.getConfig()
-	if cfg == nil || (index < 0 && len(cfg.Connections) <= index) {
+	if cfg == nil || index < 0 || len(cfg.Connections) <= index {
 		return nil
 	}
 	return cfg.Connections[index]

--- a/internal/handler/hover.go
+++ b/internal/handler/hover.go
@@ -35,7 +35,7 @@ func (s *Server) handleTextDocumentHover(ctx context.Context, conn *jsonrpc2.Con
 
 	res, err := hover(f.Text, params, s.worker.Cache())
 	if err != nil {
-		if errors.Is(ErrNoHover, err) {
+		if errors.Is(err, ErrNoHover) {
 			return nil, nil
 		}
 		return nil, err


### PR DESCRIPTION
A collection of small correctness fixes in the LSP handler:

- `getConnection` used `&&` in its bounds check, making it unsatisfiable; an out-of-range index from `switchConnections` caused an index-out-of-range panic instead of a clean error.
- `newDBRepository` dereferenced nil when no connection was configured; `showDatabases`, `showSchemas` and `showTables` now return `no database connection` instead of panicking.
- The reconnection message severity was inverted: genuine connection failures were shown as info while the benign "no connection configured" case popped an error dialog. Also fixed reversed `errors.Is` argument order here and in hover.
- `switchConnections` discarded the `strconv.Atoi` error and wrapped an always-nil error, producing `%!w(<nil>)` in the message.
- `getStatements` formatted the nil assertion result instead of the offending node in its error message.
- `didChange` with an empty `contentChanges` array no longer panics.