### PR TITLE
Handle UTF-16 offsets in completion cursor text

### DIFF
--- a/internal/completer/completer.go
+++ b/internal/completer/completer.go
@@ -451,13 +451,29 @@ func getBeforeCursorText(text string, line, char int) string {
 	for scanner.Scan() {
 		if i == line {
 			t := scanner.Text()
-			writer.Write([]byte(t[:char]))
+			writer.WriteString(t[:byteOffsetForUTF16(t, char)])
 			break
 		}
 		fmt.Fprintln(writer, scanner.Text())
 		i++
 	}
 	return writer.String()
+}
+
+// byteOffsetForUTF16 converts an LSP UTF-16 character offset to a byte
+// offset in s, clamping to the end of the string.
+func byteOffsetForUTF16(s string, char int) int {
+	utf16Pos := 0
+	for bytePos, r := range s {
+		if utf16Pos >= char {
+			return bytePos
+		}
+		utf16Pos++
+		if r > 0xFFFF {
+			utf16Pos++
+		}
+	}
+	return len(s)
 }
 
 func toQuotedCandidates(candidates []lsp.CompletionItem) []lsp.CompletionItem {

--- a/internal/completer/completer_test.go
+++ b/internal/completer/completer_test.go
@@ -23,6 +23,10 @@ hogetable
 		{input, 2, 3, "SELECT\na, "},
 		{input, 3, 4, "SELECT\na, b, c\nFROM"},
 		{input, 4, 5, "SELECT\na, b, c\nFROM\nhoget"},
+		{"select 'テスト', ci", 1, 16, "select 'テスト', ci"},
+		{"select '😀', ci", 1, 15, "select '😀', ci"},
+		{"select '😀', ci", 1, 13, "select '😀', "},
+		{"select 1", 1, 100, "select 1"},
 	}
 	for _, tt := range tests {
 		got := getBeforeCursorText(tt.in, tt.line, tt.char)


### PR DESCRIPTION
`getBeforeCursorText` used the LSP UTF-16 character offset directly as a byte index into the line. With multi-byte characters before the cursor (e.g. `select 'テスト', ci`) the slice cut mid-rune, so the last word was lost and candidate filtering silently stopped working; an offset past the line's byte length caused a slice-bounds panic. Convert the UTF-16 offset to a byte offset (surrogate pairs included) and clamp it to the line length.