### PR TITLE
Return query errors instead of calling log.Fatal

### DIFF
--- a/internal/database/clickhouse.go
+++ b/internal/database/clickhouse.go
@@ -246,7 +246,7 @@ WHERE  ( c.database = currentDatabase()
        AND c.table NOT LIKE '%inner%'
 `)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tableInfos := []*ColumnDesc{}

--- a/internal/database/h2.go
+++ b/internal/database/h2.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 
 	_ "github.com/CodinGame/h2go"
 	"github.com/sqls-server/sqls/dialect"
@@ -79,7 +78,7 @@ func (db *H2DBRepository) Schemas(ctx context.Context) ([]string, error) {
 	SELECT schema_name FROM information_schema.schemata
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	schemas := []string{}
@@ -141,7 +140,7 @@ func (db *H2DBRepository) Tables(ctx context.Context) ([]string, error) {
 		table_name
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tables := []string{}
@@ -183,7 +182,7 @@ func (db *H2DBRepository) DescribeDatabaseTable(ctx context.Context) ([]*ColumnD
 		c.ordinal_position
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tableInfos := []*ColumnDesc{}
@@ -238,7 +237,7 @@ func (db *H2DBRepository) DescribeDatabaseTableBySchema(ctx context.Context, sch
 		c.ordinal_position
 	`, schemaName))
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tableInfos := []*ColumnDesc{}

--- a/internal/database/mssql.go
+++ b/internal/database/mssql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 	"net/url"
 	"os"
 	"strconv"
@@ -109,7 +108,7 @@ func (db *MssqlDBRepository) Databases(ctx context.Context) ([]string, error) {
 	SELECT name FROM sys.databases
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	databases := []string{}
@@ -142,7 +141,7 @@ func (db *MssqlDBRepository) Schemas(ctx context.Context) ([]string, error) {
 	SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	databases := []string{}
@@ -204,7 +203,7 @@ func (db *MssqlDBRepository) Tables(ctx context.Context) ([]string, error) {
 	  TABLE_NAME
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tables := []string{}
@@ -250,7 +249,7 @@ func (db *MssqlDBRepository) DescribeDatabaseTable(ctx context.Context) ([]*Colu
 		c.ORDINAL_POSITION
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tableInfos := []*ColumnDesc{}
@@ -308,7 +307,7 @@ func (db *MssqlDBRepository) DescribeDatabaseTableBySchema(ctx context.Context, 
 		c.ORDINAL_POSITION
 	`, schemaName)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tableInfos := []*ColumnDesc{}
@@ -357,7 +356,7 @@ func (db *MssqlDBRepository) DescribeForeignKeysBySchema(ctx context.Context, sc
 	order by fk.name, fkc.constraint_object_id
 		`, schemaName)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
 	return parseForeignKeys(rows, schemaName)

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 	"net"
 	"strconv"
 
@@ -323,7 +322,7 @@ func (db *MySQLDBRepository) DescribeForeignKeysBySchema(ctx context.Context, sc
 			 kcu.ORDINAL_POSITION
 		`, schemaName)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
 	return parseForeignKeys(rows, schemaName)

--- a/internal/database/oracle.go
+++ b/internal/database/oracle.go
@@ -252,7 +252,7 @@ func (db *OracleDBRepository) DescribeForeignKeysBySchema(ctx context.Context, s
 	ORDER BY a.CONSTRAINT_NAME, a.POSITION
 		`, schemaName)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
 	return parseForeignKeys(rows, schemaName)

--- a/internal/database/postgresql.go
+++ b/internal/database/postgresql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 	"net"
 	"net/url"
 	"sort"
@@ -110,7 +109,7 @@ func (db *PostgreSQLDBRepository) Databases(ctx context.Context) ([]string, erro
 	SELECT datname FROM pg_database
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	databases := []string{}
@@ -143,7 +142,7 @@ func (db *PostgreSQLDBRepository) Schemas(ctx context.Context) ([]string, error)
 	SELECT schema_name FROM information_schema.schemata
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	databases := []string{}
@@ -205,7 +204,7 @@ func (db *PostgreSQLDBRepository) Tables(ctx context.Context) ([]string, error) 
 	  table_name
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tables := []string{}
@@ -259,7 +258,7 @@ func (db *PostgreSQLDBRepository) DescribeDatabaseTable(ctx context.Context) ([]
 		c.ordinal_position
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tableInfos := []*ColumnDesc{}
@@ -326,7 +325,7 @@ func (db *PostgreSQLDBRepository) DescribeDatabaseTableBySchema(ctx context.Cont
 		c.ordinal_position
 	`, schemaName, schemaName)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tableInfos := []*ColumnDesc{}
@@ -376,7 +375,7 @@ func (db *PostgreSQLDBRepository) DescribeForeignKeysBySchema(ctx context.Contex
 			 kcu.ORDINAL_POSITION
 		`, schemaName)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
 	return parseForeignKeys(rows, schemaName)

--- a/internal/database/sqlite3.go
+++ b/internal/database/sqlite3.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/sqls-server/sqls/dialect"
@@ -75,7 +74,7 @@ func (db *SQLite3DBRepository) Tables(ctx context.Context) ([]string, error) {
 	  name
 	`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tables := []string{}
@@ -92,7 +91,7 @@ func (db *SQLite3DBRepository) Tables(ctx context.Context) ([]string, error) {
 func (db *SQLite3DBRepository) describeTable(ctx context.Context, tableName string) ([]*ColumnDesc, error) {
 	rows, err := db.Conn.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s);", tableName))
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer rows.Close()
 	tableInfos := []*ColumnDesc{}
@@ -157,7 +156,7 @@ func (db *SQLite3DBRepository) DescribeForeignKeysBySchema(ctx context.Context, 
 	ORDER BY 1, p."seq"
 		`)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
 	return parseForeignKeys(rows, schemaName)


### PR DESCRIPTION
The repository fetch methods for PostgreSQL, MySQL, MSSQL, SQLite, H2, Oracle and ClickHouse called `log.Fatal(err)` when `QueryContext` failed, terminating the whole language server process on any transient query error (e.g. a dropped connection during a cache refresh). All 22 call sites now return the error to the caller as the surrounding signatures already allow.