### PR TITLE
Fix data race and nil overwrite in cache worker

### DIFF
--- a/internal/database/worker.go
+++ b/internal/database/worker.go
@@ -23,6 +23,8 @@ func NewWorker() *Worker {
 }
 
 func (w *Worker) Cache() *DBCache {
+	w.lock.Lock()
+	defer w.lock.Unlock()
 	return w.dbCache
 }
 
@@ -36,7 +38,11 @@ func (w *Worker) setColumnCache(col map[string][]*ColumnDesc) {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 	if w.dbCache != nil {
-		w.dbCache.ColumnsWithParent = col
+		// Swap in a copy so that readers holding the previous
+		// *DBCache keep seeing a consistent snapshot.
+		newCache := *w.dbCache
+		newCache.ColumnsWithParent = col
+		w.dbCache = &newCache
 	}
 }
 
@@ -53,6 +59,7 @@ func (w *Worker) Start() {
 				col, err := generator.GenerateDBCacheSecondary(context.Background())
 				if err != nil {
 					log.Println(err)
+					continue
 				}
 				w.setColumnCache(col)
 				log.Println("db worker: Update db cache secondary complete")


### PR DESCRIPTION
Two fixes in the background cache worker:

- `Cache()` read `w.dbCache` without the lock while the worker goroutine updates it, an unsynchronized read/write flagged by the race detector. The getter now takes the lock, and `setColumnCache` swaps in a copied `DBCache` so readers holding the old pointer keep a consistent snapshot.
- When `GenerateDBCacheSecondary` failed, the nil result still overwrote `ColumnsWithParent`, wiping the column cache populated by the primary pass. The worker now keeps the existing cache on error.