### PR TITLE
Close rows before scan loop in oracle and vertica

### DIFF
--- a/internal/database/oracle.go
+++ b/internal/database/oracle.go
@@ -209,6 +209,7 @@ func (db *OracleDBRepository) DescribeDatabaseTableBySchema(ctx context.Context,
 		log.Println("schema", schemaName, err.Error())
 		return nil, err
 	}
+	defer rows.Close()
 	tableInfos := []*ColumnDesc{}
 	for rows.Next() {
 		var tableInfo ColumnDesc
@@ -227,7 +228,6 @@ func (db *OracleDBRepository) DescribeDatabaseTableBySchema(ctx context.Context,
 		}
 		tableInfos = append(tableInfos, &tableInfo)
 	}
-	defer rows.Close()
 	return tableInfos, nil
 }
 

--- a/internal/database/vertica.go
+++ b/internal/database/vertica.go
@@ -207,6 +207,7 @@ func (db *VerticaDBRepository) DescribeDatabaseTableBySchema(ctx context.Context
 		log.Println("schema", schemaName, err.Error())
 		return nil, err
 	}
+	defer rows.Close()
 	tableInfos := []*ColumnDesc{}
 	for rows.Next() {
 		var tableInfo ColumnDesc
@@ -225,7 +226,6 @@ func (db *VerticaDBRepository) DescribeDatabaseTableBySchema(ctx context.Context
 		}
 		tableInfos = append(tableInfos, &tableInfo)
 	}
-	defer rows.Close()
 	return tableInfos, nil
 }
 


### PR DESCRIPTION
`DescribeDatabaseTableBySchema` in the Oracle and Vertica repositories registered `defer rows.Close()` after the scan loop, so an early `return nil, err` inside the loop leaked the `sql.Rows`. With `DefaultMaxOpenConns = 5`, repeated scan failures pin connections until the pool is exhausted. Move the defer directly after the query error check, matching every other method in these files.