### PR TITLE
Fix MySQL unix socket config and SSH tunnel dialer

### DIFF
--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -34,6 +34,8 @@ func mysqlOpen(dbConnCfg *DBConfig) (*DBConnection, error) {
 	}
 
 	if dbConnCfg.SSHCfg != nil {
+		// Route the connection through the dialer registered by openMySQLViaSSH.
+		cfg.Net = "mysql+tcp"
 		dbConn, dbSSHConn, err := openMySQLViaSSH(cfg.FormatDSN(), dbConnCfg.SSHCfg)
 		if err != nil {
 			return nil, err
@@ -109,11 +111,11 @@ func genMysqlConfig(connCfg *DBConfig) (*mysql.Config, error) {
 		cfg.Addr = host + ":" + strconv.Itoa(port)
 		cfg.Net = string(connCfg.Proto)
 	case ProtoUnix:
-		if connCfg.Path != "" {
+		if connCfg.Path == "" {
 			cfg.Addr = "/tmp/mysql.sock"
-			break
+		} else {
+			cfg.Addr = connCfg.Path
 		}
-		cfg.Addr = connCfg.Path
 		cfg.Net = string(connCfg.Proto)
 	case ProtoHTTP:
 	default:

--- a/internal/database/mysql_test.go
+++ b/internal/database/mysql_test.go
@@ -1,0 +1,57 @@
+package database
+
+import (
+	"testing"
+)
+
+func Test_genMysqlConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		connCfg  *DBConfig
+		wantNet  string
+		wantAddr string
+	}{
+		{
+			name: "tcp defaults",
+			connCfg: &DBConfig{
+				Proto: ProtoTCP,
+				User:  "user",
+			},
+			wantNet:  "tcp",
+			wantAddr: "127.0.0.1:3306",
+		},
+		{
+			name: "unix socket with path",
+			connCfg: &DBConfig{
+				Proto: ProtoUnix,
+				User:  "user",
+				Path:  "/var/run/mysqld/mysqld.sock",
+			},
+			wantNet:  "unix",
+			wantAddr: "/var/run/mysqld/mysqld.sock",
+		},
+		{
+			name: "unix socket without path",
+			connCfg: &DBConfig{
+				Proto: ProtoUnix,
+				User:  "user",
+			},
+			wantNet:  "unix",
+			wantAddr: "/tmp/mysql.sock",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := genMysqlConfig(tt.connCfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.Net != tt.wantNet {
+				t.Errorf("want Net %q, got %q", tt.wantNet, cfg.Net)
+			}
+			if cfg.Addr != tt.wantAddr {
+				t.Errorf("want Addr %q, got %q", tt.wantAddr, cfg.Addr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two MySQL connection bugs:

- The `proto: unix` branch had its condition inverted: a configured socket path was discarded in favor of the hard-coded `/tmp/mysql.sock`, and `Net` was left empty so the driver dialed it as TCP. Unix-socket connections could never use the configured path.
- `openMySQLViaSSH` registers its dialer under the net name `mysql+tcp`, but the DSN was generated with `Net: "tcp"`, so go-sql-driver never selected the SSH dialer and silently dialed the database host directly, bypassing the tunnel. The config now uses `mysql+tcp` when an SSH config is present.