### PR TITLE
Fix MSSQL SSH key parsing and close tunnel on disconnect

### DIFF
--- a/internal/database/driver.go
+++ b/internal/database/driver.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"io"
 
 	"github.com/sqls-server/sqls/dialect"
 	"golang.org/x/crypto/ssh"
@@ -17,6 +18,7 @@ type Factory func(*sql.DB) DBRepository
 type DBConnection struct {
 	Conn    *sql.DB
 	SSHConn *ssh.Client
+	Tunnel  io.Closer
 	Driver  dialect.DatabaseDriver
 }
 
@@ -29,6 +31,11 @@ func (db *DBConnection) Close() error {
 	}
 	if db.SSHConn != nil {
 		if err := db.SSHConn.Close(); err != nil {
+			return err
+		}
+	}
+	if db.Tunnel != nil {
+		if err := db.Tunnel.Close(); err != nil {
 			return err
 		}
 	}

--- a/internal/database/mssql.go
+++ b/internal/database/mssql.go
@@ -5,14 +5,12 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
-	"os"
 	"strconv"
 
 	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/jfcote87/sshdb"
 	"github.com/jfcote87/sshdb/mssql"
 	"github.com/sqls-server/sqls/dialect"
-	"golang.org/x/crypto/ssh"
 )
 
 func init() {
@@ -29,28 +27,16 @@ func mssqlOpen(dbConnCfg *DBConfig) (*DBConnection, error) {
 		return nil, err
 	}
 
+	var tunnel *sshdb.Tunnel
 	if dbConnCfg.SSHCfg != nil {
-		key, err := os.ReadFile(dbConnCfg.SSHCfg.PrivateKey)
+		cfg, err := dbConnCfg.SSHCfg.ClientConfig()
 		if err != nil {
-			return nil, fmt.Errorf("unable to open private key")
-		}
-
-		signer, err := ssh.ParsePrivateKeyWithPassphrase(key, []byte(dbConnCfg.SSHCfg.PassPhrase))
-		if err != nil {
-			return nil, fmt.Errorf("unable to decrypt private key")
-		}
-
-		cfg := &ssh.ClientConfig{
-			User: dbConnCfg.SSHCfg.User,
-			Auth: []ssh.AuthMethod{
-				ssh.PublicKeys(signer),
-			},
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			return nil, err
 		}
 
 		remoteAddr := fmt.Sprintf("%s:%d", dbConnCfg.SSHCfg.Host, dbConnCfg.SSHCfg.Port)
 
-		tunnel, err := sshdb.New(cfg, remoteAddr)
+		tunnel, err = sshdb.New(cfg, remoteAddr)
 		if err != nil {
 			return nil, fmt.Errorf("%w", err)
 		}
@@ -75,9 +61,14 @@ func mssqlOpen(dbConnCfg *DBConfig) (*DBConnection, error) {
 	conn.SetMaxIdleConns(DefaultMaxIdleConns)
 	conn.SetMaxOpenConns(DefaultMaxOpenConns)
 
-	return &DBConnection{
-		Conn: conn,
-	}, nil
+	dbConn := &DBConnection{
+		Conn:   conn,
+		Driver: dbConnCfg.Driver,
+	}
+	if tunnel != nil {
+		dbConn.Tunnel = tunnel
+	}
+	return dbConn, nil
 }
 
 type MssqlDBRepository struct {


### PR DESCRIPTION
The MSSQL SSH path called `ssh.ParsePrivateKeyWithPassphrase` unconditionally, which fails on unencrypted private keys, so mssql over SSH only worked with passphrase-protected keys. It now uses `SSHConfig.ClientConfig()`, the same helper every other driver uses, which branches on an empty passphrase.

The `sshdb` tunnel was also never stored on the connection, so it leaked when switching connections; `DBConnection` now closes it. The mssql connection also gains the `Driver` field that every other driver sets.