### PR TITLE
Fix Vertica DSN format and ClickHouse DSN defaults

### DIFF
--- a/internal/database/clickhouse.go
+++ b/internal/database/clickhouse.go
@@ -57,6 +57,7 @@ func clickhouseOpen(dbConnCfg *DBConfig) (*DBConnection, error) {
 	return &DBConnection{
 		Conn:    conn,
 		SSHConn: sshConn,
+		Driver:  dbConnCfg.Driver,
 	}, nil
 }
 
@@ -107,7 +108,18 @@ func genClickhouseDsn(dbConfig *DBConfig) (string, error) {
 		u.User = url.UserPassword(dbConfig.User, dbConfig.Passwd)
 	}
 
-	u.Host = fmt.Sprintf("%s:%d", dbConfig.Host, dbConfig.Port)
+	host, port := dbConfig.Host, dbConfig.Port
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if port == 0 {
+		if dbConfig.Proto == ProtoHTTP {
+			port = 8123
+		} else {
+			port = 9000
+		}
+	}
+	u.Host = fmt.Sprintf("%s:%d", host, port)
 
 	if dbConfig.DBName != "" {
 		u.Path = dbConfig.DBName

--- a/internal/database/clickhouse_test.go
+++ b/internal/database/clickhouse_test.go
@@ -39,6 +39,16 @@ func TestGenClickhouseDsn(t *testing.T) {
 			},
 			want: "clickhouse://test:secure@localhost:9001/default?dial_timeout=200ms",
 		},
+		{
+			name: "default host and port",
+			connCfg: &DBConfig{
+				Driver: "clickhouse",
+				Proto:  "tcp",
+				User:   "test",
+				DBName: "default",
+			},
+			want: "clickhouse://test@127.0.0.1:9000/default",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/database/vertica.go
+++ b/internal/database/vertica.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
+	"net/url"
+	"strconv"
+
 	"github.com/sqls-server/sqls/dialect"
 	_ "github.com/vertica/vertica-sql-go"
-	"log"
-	"strconv"
 )
 
 func init() {
@@ -51,8 +53,13 @@ func genVerticaConfig(connCfg *DBConfig) (string, error) {
 		port = 5433
 	}
 
-	DSName := connCfg.User + "/" + connCfg.Passwd + "@" + host + ":" + strconv.Itoa(port) + "/" + connCfg.DBName
-	return DSName, nil
+	u := url.URL{
+		Scheme: "vertica",
+		User:   url.UserPassword(connCfg.User, connCfg.Passwd),
+		Host:   host + ":" + strconv.Itoa(port),
+		Path:   "/" + connCfg.DBName,
+	}
+	return u.String(), nil
 }
 
 type VerticaDBRepository struct {

--- a/internal/database/vertica_test.go
+++ b/internal/database/vertica_test.go
@@ -1,0 +1,50 @@
+package database
+
+import "testing"
+
+func Test_genVerticaConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		connCfg *DBConfig
+		want    string
+	}{
+		{
+			name: "use datasource name",
+			connCfg: &DBConfig{
+				DataSourceName: "vertica://user:pwd@localhost:5433/db",
+			},
+			want: "vertica://user:pwd@localhost:5433/db",
+		},
+		{
+			name: "use config properties",
+			connCfg: &DBConfig{
+				User:   "dbadmin",
+				Passwd: "secure",
+				Host:   "example.com",
+				Port:   15433,
+				DBName: "vdb",
+			},
+			want: "vertica://dbadmin:secure@example.com:15433/vdb",
+		},
+		{
+			name: "defaults",
+			connCfg: &DBConfig{
+				User:   "dbadmin",
+				Passwd: "secure",
+				DBName: "vdb",
+			},
+			want: "vertica://dbadmin:secure@127.0.0.1:5433/vdb",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := genVerticaConfig(tt.connCfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Vertica DSN was built in Oracle's `user/pass@host:port/db` format, but vertica-sql-go parses the connection string with `url.Parse` and dials `connURL.Host` — a scheme-less string parses entirely into `Path`, so host/port configs could never connect. Build a proper `vertica://user:pass@host:port/db` URL instead.

`genClickhouseDsn` also applied no host/port defaults, unlike every other driver, producing `host:0` when the port was omitted. Default to 127.0.0.1 with the protocol-appropriate port (9000 native, 8123 HTTP). The ClickHouse connection now also carries the `Driver` field like the other drivers.