### PR TITLE
Check rows.Err after iteration in repository fetch loops

### DIFF
--- a/internal/database/clickhouse.go
+++ b/internal/database/clickhouse.go
@@ -217,6 +217,9 @@ func (db *clickhouseSQLDBRepository) Databases(ctx context.Context) ([]string, e
 		}
 		databases = append(databases, database)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databases, nil
 }
 
@@ -270,6 +273,9 @@ WHERE  ( c.database = currentDatabase()
 			tableInfo.Name = *columnName
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }
@@ -326,6 +332,9 @@ WHERE  ( c.database = ?
 		}
 		tableInfos = append(tableInfos, &tableInfo)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return tableInfos, nil
 }
 
@@ -370,6 +379,9 @@ func (db *clickhouseSQLDBRepository) SchemaTables(ctx context.Context) (map[stri
 		} else {
 			databaseTables[schema] = []string{table}
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return databaseTables, nil
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -216,5 +216,8 @@ func parseForeignKeys(rows *sql.Rows, schemaName string) ([]*ForeignKey, error) 
 	if cur != nil {
 		retVal = append(retVal, cur)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return retVal, nil
 }

--- a/internal/database/h2.go
+++ b/internal/database/h2.go
@@ -89,6 +89,9 @@ func (db *H2DBRepository) Schemas(ctx context.Context) ([]string, error) {
 		}
 		schemas = append(schemas, schema)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return schemas, nil
 }
 
@@ -122,6 +125,9 @@ func (db *H2DBRepository) SchemaTables(ctx context.Context) (map[string][]string
 			databaseTables[schema] = []string{table}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databaseTables, nil
 }
 
@@ -150,6 +156,9 @@ func (db *H2DBRepository) Tables(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		tables = append(tables, table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tables, nil
 }
@@ -202,6 +211,9 @@ func (db *H2DBRepository) DescribeDatabaseTable(ctx context.Context) ([]*ColumnD
 			return nil, err
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }
@@ -257,6 +269,9 @@ func (db *H2DBRepository) DescribeDatabaseTableBySchema(ctx context.Context, sch
 			return nil, err
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }

--- a/internal/database/mssql.go
+++ b/internal/database/mssql.go
@@ -110,6 +110,9 @@ func (db *MssqlDBRepository) Databases(ctx context.Context) ([]string, error) {
 		}
 		databases = append(databases, database)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databases, nil
 }
 
@@ -142,6 +145,9 @@ func (db *MssqlDBRepository) Schemas(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		databases = append(databases, database)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return databases, nil
 }
@@ -176,6 +182,9 @@ func (db *MssqlDBRepository) SchemaTables(ctx context.Context) (map[string][]str
 			databaseTables[schema] = []string{table}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databaseTables, nil
 }
 
@@ -204,6 +213,9 @@ func (db *MssqlDBRepository) Tables(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		tables = append(tables, table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tables, nil
 }
@@ -260,6 +272,9 @@ func (db *MssqlDBRepository) DescribeDatabaseTable(ctx context.Context) ([]*Colu
 			return nil, err
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }
@@ -318,6 +333,9 @@ func (db *MssqlDBRepository) DescribeDatabaseTableBySchema(ctx context.Context, 
 			return nil, err
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }

--- a/internal/database/mysql.go
+++ b/internal/database/mysql.go
@@ -163,6 +163,9 @@ func (db *MySQLDBRepository) Databases(ctx context.Context) ([]string, error) {
 		}
 		databases = append(databases, database)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databases, nil
 }
 
@@ -204,6 +207,9 @@ func (db *MySQLDBRepository) SchemaTables(ctx context.Context) (map[string][]str
 			databaseTables[schema] = []string{table}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databaseTables, nil
 }
 
@@ -220,6 +226,9 @@ func (db *MySQLDBRepository) Tables(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		tables = append(tables, table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tables, nil
 }
@@ -261,6 +270,9 @@ FROM information_schema.COLUMNS
 		}
 		tableInfos = append(tableInfos, &tableInfo)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return tableInfos, nil
 }
 
@@ -301,6 +313,9 @@ WHERE information_schema.COLUMNS.TABLE_SCHEMA = ?
 			return nil, err
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }

--- a/internal/database/oracle.go
+++ b/internal/database/oracle.go
@@ -90,6 +90,9 @@ func (db *OracleDBRepository) Databases(ctx context.Context) ([]string, error) {
 		}
 		databases = append(databases, database)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databases, nil
 }
 
@@ -126,6 +129,9 @@ func (db *OracleDBRepository) SchemaTables(ctx context.Context) (map[string][]st
 			databaseTables[schema] = []string{table}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databaseTables, nil
 }
 
@@ -142,6 +148,9 @@ func (db *OracleDBRepository) Tables(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		tables = append(tables, table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tables, nil
 }
@@ -182,6 +191,9 @@ FROM SYS.ALL_TAB_COLUMNS
 			return nil, err
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }
@@ -227,6 +239,9 @@ func (db *OracleDBRepository) DescribeDatabaseTableBySchema(ctx context.Context,
 			return nil, err
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }

--- a/internal/database/postgresql.go
+++ b/internal/database/postgresql.go
@@ -120,6 +120,9 @@ func (db *PostgreSQLDBRepository) Databases(ctx context.Context) ([]string, erro
 		}
 		databases = append(databases, database)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databases, nil
 }
 
@@ -152,6 +155,9 @@ func (db *PostgreSQLDBRepository) Schemas(ctx context.Context) ([]string, error)
 			return nil, err
 		}
 		databases = append(databases, database)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return databases, nil
 }
@@ -186,6 +192,9 @@ func (db *PostgreSQLDBRepository) SchemaTables(ctx context.Context) (map[string]
 			databaseTables[schema] = []string{table}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databaseTables, nil
 }
 
@@ -214,6 +223,9 @@ func (db *PostgreSQLDBRepository) Tables(ctx context.Context) ([]string, error) 
 			return nil, err
 		}
 		tables = append(tables, table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tables, nil
 }
@@ -278,6 +290,9 @@ func (db *PostgreSQLDBRepository) DescribeDatabaseTable(ctx context.Context) ([]
 			return nil, err
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }
@@ -345,6 +360,9 @@ func (db *PostgreSQLDBRepository) DescribeDatabaseTableBySchema(ctx context.Cont
 			return nil, err
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }

--- a/internal/database/sqlite3.go
+++ b/internal/database/sqlite3.go
@@ -85,6 +85,9 @@ func (db *SQLite3DBRepository) Tables(ctx context.Context) ([]string, error) {
 		}
 		tables = append(tables, table)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return tables, nil
 }
 
@@ -117,6 +120,9 @@ func (db *SQLite3DBRepository) describeTable(ctx context.Context, tableName stri
 			tableInfo.Null = "YES"
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }

--- a/internal/database/vertica.go
+++ b/internal/database/vertica.go
@@ -90,6 +90,9 @@ func (db *VerticaDBRepository) Databases(ctx context.Context) ([]string, error) 
 		}
 		databases = append(databases, database)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databases, nil
 }
 
@@ -126,6 +129,9 @@ func (db *VerticaDBRepository) SchemaTables(ctx context.Context) (map[string][]s
 			databaseTables[schema] = []string{table}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databaseTables, nil
 }
 
@@ -142,6 +148,9 @@ func (db *VerticaDBRepository) Tables(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 		tables = append(tables, table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tables, nil
 }
@@ -181,6 +190,9 @@ SELECT table_schema,
 			return nil, err
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }
@@ -225,6 +237,9 @@ func (db *VerticaDBRepository) DescribeDatabaseTableBySchema(ctx context.Context
 			return nil, err
 		}
 		tableInfos = append(tableInfos, &tableInfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return tableInfos, nil
 }


### PR DESCRIPTION
If the connection drops mid-iteration, `rows.Next()` returns false silently and the truncated result was returned as success, leaving the schema cache with a partial table or column list and no reported error. Add the missing `rows.Err()` check after every fetch loop in the driver repositories and in `parseForeignKeys`, completing the pattern that c40ed60 applied to `ScanRows`.