### PR TITLE
Keep consumed keywords on partial multi-keyword match

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -284,6 +284,11 @@ func parseMultiKeyword(reader *astutil.NodeReader) ast.Node {
 			break
 		}
 		if !reader.PeekNodeIs(true, astutil.NodeMatcher{ExpectKeyword: peekKeywords}) {
+			if len(keywords) > 1 {
+				// Partial match. Keep the keywords consumed so far
+				// so they are not dropped from the statement.
+				break
+			}
 			return reader.CurNode
 		}
 		reader.NextNode(true)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -565,6 +565,15 @@ func TestParseMultiKeyword(t *testing.T) {
 			},
 		},
 		{
+			name:  "partial multi keyword",
+			input: "select * from a natural left foo",
+			checkFn: func(t *testing.T, stmts []*ast.Statement, input string) {
+				testStatement(t, stmts[0], 11, input)
+				list := stmts[0].GetTokens()
+				testMultiKeyword(t, list[8], "natural left")
+			},
+		},
+		{
 			name:  "select with group keyword",
 			input: "select a, b, c from abc group by d, e, f",
 			checkFn: func(t *testing.T, stmts []*ast.Statement, input string) {


### PR DESCRIPTION
When `parseMultiKeyword` had already consumed one or more keywords and the next peek failed (e.g. the in-progress query `select * from a natural left foo`), it returned only the current node, silently dropping the earlier keywords and whitespace from the AST — the statement round-tripped as `select * from a left foo`. On a partial match the consumed keywords are now kept as a MultiKeyword node so the source text is preserved.