### PR TITLE
Fix JSON tag of CompletionContext in CompletionParams

### DIFF
--- a/internal/lsp/lsp.go
+++ b/internal/lsp/lsp.go
@@ -121,7 +121,7 @@ type DidCloseTextDocumentParams struct {
 
 type CompletionParams struct {
 	TextDocumentPositionParams
-	CompletionContext CompletionContext `json:"contentChanges"`
+	CompletionContext CompletionContext `json:"context"`
 }
 
 type CompletionContext struct {


### PR DESCRIPTION
`CompletionParams.CompletionContext` carried the JSON tag `contentChanges`, copied from `DidChangeTextDocumentParams`, instead of `context` as defined by the LSP specification, so the completion context sent by clients was never decoded.