### PR TITLE
Fix stack overflow on CASE without END

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -704,7 +704,12 @@ func parseCase(reader *astutil.NodeReader) ast.Node {
 		}
 		nodes = append(nodes, tmpReader.CurNode)
 	}
-	return reader.Node
+
+	// Not found close "END". Keep the nodes consumed so far instead of
+	// returning the enclosing list, which would create a cyclic AST.
+	reader.Index = tmpReader.Index
+	reader.CurNode = tmpReader.CurNode
+	return &ast.SwitchCase{Toks: nodes}
 }
 
 var expressionPrefixMatcher = astutil.NodeMatcher{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1231,6 +1231,15 @@ func TestParseCase(t *testing.T) {
 				testIdentifierList(t, list[0], input)
 			},
 		},
+		{
+			name:  "case without end",
+			input: "SELECT CASE WHEN a THEN b",
+			checkFn: func(t *testing.T, stmts []*ast.Statement, input string) {
+				testStatement(t, stmts[0], 3, input)
+				list := stmts[0].GetTokens()
+				testSwitchCase(t, list[2], "CASE WHEN a THEN b")
+			},
+		},
 	}
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When no closing `END` was found, `parseCase` returned the enclosing statement list itself, so `parsePrefixGroup` appended the list into its own token slice, producing a cyclic AST. Any document containing an unterminated CASE expression — e.g. mid-typing `SELECT CASE WHEN a THEN b` — crashed the whole server with an unrecoverable `fatal error: stack overflow` on the next request. Return a SwitchCase of the nodes consumed so far instead, mirroring how unclosed parentheses are handled.