### PR TITLE
Map sqlite3 pk column to YES/NO in column description

### DIFF
--- a/internal/database/sqlite3.go
+++ b/internal/database/sqlite3.go
@@ -101,6 +101,7 @@ func (db *SQLite3DBRepository) describeTable(ctx context.Context, tableName stri
 	for rows.Next() {
 		var id int
 		var nonnull int
+		var pk int
 		var tableInfo ColumnDesc
 		err := rows.Scan(
 			&id,
@@ -108,7 +109,7 @@ func (db *SQLite3DBRepository) describeTable(ctx context.Context, tableName stri
 			&tableInfo.Type,
 			&nonnull,
 			&tableInfo.Default,
-			&tableInfo.Key,
+			&pk,
 		)
 		if err != nil {
 			return nil, err
@@ -118,6 +119,11 @@ func (db *SQLite3DBRepository) describeTable(ctx context.Context, tableName stri
 			tableInfo.Null = "NO"
 		} else {
 			tableInfo.Null = "YES"
+		}
+		if pk != 0 {
+			tableInfo.Key = "YES"
+		} else {
+			tableInfo.Key = "NO"
 		}
 		tableInfos = append(tableInfos, &tableInfo)
 	}


### PR DESCRIPTION
`describeTable` scanned the integer `pk` column of `PRAGMA table_info` directly into the string field `ColumnDesc.Key`, so hovers and table docs showed `0`/`1` instead of marking primary keys — `OnelineDesc` checks for `Key == "YES"` and appends any other non-empty value verbatim. Convert it to `YES`/`NO` like the adjacent `notnull` handling and every other driver.