### PR TITLE
Quote PostgreSQL DSN values containing spaces or quotes

### DIFF
--- a/internal/database/postgresql.go
+++ b/internal/database/postgresql.go
@@ -413,9 +413,9 @@ func genPostgresConfig(connCfg *DBConfig) (string, error) {
 	}
 
 	q := url.Values{}
-	q.Set("user", connCfg.User)
-	q.Set("password", connCfg.Passwd)
-	q.Set("dbname", connCfg.DBName)
+	q.Set("user", quotePostgresParam(connCfg.User))
+	q.Set("password", quotePostgresParam(connCfg.Passwd))
+	q.Set("dbname", quotePostgresParam(connCfg.DBName))
 
 	switch connCfg.Proto {
 	case ProtoTCP, ProtoUDP:
@@ -426,20 +426,31 @@ func genPostgresConfig(connCfg *DBConfig) (string, error) {
 		if port == 0 {
 			port = 5432
 		}
-		q.Set("host", host)
+		q.Set("host", quotePostgresParam(host))
 		q.Set("port", strconv.Itoa(port))
 	case ProtoUnix:
-		q.Set("host", connCfg.Path)
+		q.Set("host", quotePostgresParam(connCfg.Path))
 	case ProtoHTTP:
 	default:
 		return "", fmt.Errorf("default addr for network %s unknown", connCfg.Proto)
 	}
 
 	for k, v := range connCfg.Params {
-		q.Set(k, v)
+		q.Set(k, quotePostgresParam(v))
 	}
 
 	return genOptions(q, "", "=", " ", ",", true), nil
+}
+
+// quotePostgresParam single-quotes a keyword/value connection string
+// value when it contains characters that would otherwise terminate or
+// corrupt the value (libpq requires quoting for spaces and quotes).
+func quotePostgresParam(v string) string {
+	if !strings.ContainsAny(v, " '\\") {
+		return v
+	}
+	r := strings.NewReplacer(`\`, `\\`, `'`, `\'`)
+	return "'" + r.Replace(v) + "'"
 }
 
 // genOptions takes URL values and generates options, joining together with

--- a/internal/database/postgresql_test.go
+++ b/internal/database/postgresql_test.go
@@ -33,6 +33,20 @@ func Test_genPostgresConfig(t *testing.T) {
 			want:    "dbname=dvdrental host=127.0.0.1 password=mysecretpassword1234 port=15432 sslmode=disable user=postgres",
 			wantErr: false,
 		},
+		{
+			name: "password with space and quote",
+			connCfg: &DBConfig{
+				Driver: "postgresql",
+				Proto:  "tcp",
+				User:   "postgres",
+				Passwd: `p@ss w'ord`,
+				Host:   "127.0.0.1",
+				Port:   15432,
+				DBName: "dvdrental",
+			},
+			want:    `dbname=dvdrental host=127.0.0.1 password='p@ss w\'ord' port=15432 user=postgres`,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The keyword/value DSN built by `genPostgresConfig` never quoted values, but libpq syntax requires single-quoting values containing spaces, quotes or backslashes. A password like `p@ss word` was parsed by pgx without error as `p@ss` — silently truncated — leaving the user with a baffling authentication failure. Values are now single-quoted with escaping when needed; verified that pgx round-trips the quoted form.