### PR TITLE
Default SSH port to 22 and set H2 driver field

### DIFF
--- a/internal/database/config.go
+++ b/internal/database/config.go
@@ -165,7 +165,11 @@ func (s *SSHConfig) Validate() error {
 }
 
 func (s *SSHConfig) Endpoint() string {
-	return fmt.Sprintf("%s:%d", s.Host, s.Port)
+	port := s.Port
+	if port == 0 {
+		port = 22
+	}
+	return fmt.Sprintf("%s:%d", s.Host, port)
 }
 
 func (s *SSHConfig) ClientConfig() (*ssh.ClientConfig, error) {

--- a/internal/database/h2.go
+++ b/internal/database/h2.go
@@ -52,7 +52,7 @@ type H2DBRepository struct {
 }
 
 func NewH2DBRepository(conn *sql.DB) DBRepository {
-	return &H2DBRepository{Conn: conn}
+	return &H2DBRepository{Conn: conn, driver: dialect.DatabaseDriverH2}
 }
 
 func (db *H2DBRepository) Driver() dialect.DatabaseDriver {

--- a/internal/database/mssql.go
+++ b/internal/database/mssql.go
@@ -34,9 +34,7 @@ func mssqlOpen(dbConnCfg *DBConfig) (*DBConnection, error) {
 			return nil, err
 		}
 
-		remoteAddr := fmt.Sprintf("%s:%d", dbConnCfg.SSHCfg.Host, dbConnCfg.SSHCfg.Port)
-
-		tunnel, err = sshdb.New(cfg, remoteAddr)
+		tunnel, err = sshdb.New(cfg, dbConnCfg.SSHCfg.Endpoint())
 		if err != nil {
 			return nil, fmt.Errorf("%w", err)
 		}


### PR DESCRIPTION
Two small driver fixes:

- `SSHConfig.Endpoint` used the port verbatim while `Validate` does not require one, so omitting `port` in `sshConfig` dialed `host:0` and always failed. Default to 22; the mssql SSH path now also uses `Endpoint()` instead of formatting the address itself.
- `NewH2DBRepository` never set the `driver` field, so `H2DBRepository.Driver()` returned an empty string instead of `h2`.